### PR TITLE
Backport fix that removes .PHONY for smtcoq_plugin.mlpack.d in makefile

### DIFF
--- a/src/Makefile.local
+++ b/src/Makefile.local
@@ -41,5 +41,4 @@ verit/veritParser.ml verit/veritParser.mli : verit/veritParser.mly
 %.ml %.mli :  %.mly
 	$(CAMLYACC) $<
 
-.PHONY: smtcoq_plugin.mlpack.d
 smtcoq_plugin.mlpack.d :  verit/veritParser.ml verit/veritLexer.ml ../3rdparty/alt-ergo/smtlib2_parse.ml ../3rdparty/alt-ergo/smtlib2_lex.ml smtlib2/sExprParser.ml smtlib2/sExprLexer.ml


### PR DESCRIPTION
This commit fixes a build error with newer versions of make which fails to build the smtcoq_plugin.mlpack.d target. This issue was first identified and fixed in https://github.com/smtcoq/smtcoq/pull/117.